### PR TITLE
Flush output immediately on print

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ except OSError:
 
 
 def dataRecv(client, addr):
-    print(f"[+] Connection from {addr[0]}")
+    print(f"[+] Connection from {addr[0]}", flush=True)
     for i in roll:
         if type(i) == float:
             time.sleep(i)


### PR DESCRIPTION
This will avoid docker buffering the logs until it closes, allowing for a realtime view.

May cause perf impacts if you get a few thousand simultaneous connections I guess