### PR TITLE
Run in unbuffered mode inside the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3-alpine
 WORKDIR /app
 COPY main.py main.py
 COPY rickroll.pbz2 rickroll.pbz2
-CMD python main.py
+CMD python -u main.py
 


### PR DESCRIPTION
This will avoid docker buffering the logs until it closes, allowing for a realtime view.

May cause perf impacts if you get a few thousand simultaneous connections I guess

Replaces #3 